### PR TITLE
Cmake: Find libubox/list.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,9 @@ if(${L_LEVEL})
   add_definitions(-DL_LEVEL=${L_LEVEL})
 endif(${L_LEVEL})
 
+FIND_PATH(ubox_include_dir libubox/list.h)
+INCLUDE_DIRECTORIES(${ubox_include_dir})
+
 if(WITH_LIBUBOX)
   add_definitions(-Wextra)
   set(PLATFORM_LINK ${PLATFORM_LINK} ubox)


### PR DESCRIPTION
Add a CMake FIND_PATH and INCLUDE_DIRECTORIES searching for
libubox/list.h. Some external toolchains which do not include
standard locations would fail to find the header otherwise.

Signed-off-by: Florian Fainelli <f.fainelli@gmail.com>