### PR TITLE
mrib.c: don't use cpu_to_be32 outside of function

### DIFF
--- a/src/mrib.c
+++ b/src/mrib.c
@@ -21,6 +21,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <endian.h>
 #include <sys/socket.h>
 #include <sys/ioctl.h>
 #include <unistd.h>
@@ -54,7 +55,13 @@ struct mrib_iface {
 	struct uloop_timeout timer;
 };
 
-static uint32_t ipv4_rtr_alert = cpu_to_be32(0x94040000);
+/* we can't use cpu_to_be32 outside a function */
+#if __BYTE_ORDER == __BIG_ENDIAN
+static uint32_t ipv4_rtr_alert = 0x94040000;
+#else
+static uint32_t ipv4_rtr_alert = 0x00000494;
+#endif
+
 static struct {
 	struct ip6_hbh hdr;
 	struct ip6_opt_router rt;


### PR DESCRIPTION
`cpu_to_be32` is not a constant, so it can't be used outside of a function.

Compilation fails on little-endian machines with:
```
[ 11%] Building C object CMakeFiles/omcproxy.dir/src/mrib.c.o
In file included from /var/lib/buildbot/slaves/slave-lede-builds4/mipsel_74kc/build/sdk/build_dir/target-mipsel_74kc_musl/omcproxy-2017-02-14-1fe6f48f/src/omcproxy.h:51:0,
                 from /var/lib/buildbot/slaves/slave-lede-builds4/mipsel_74kc/build/sdk/build_dir/target-mipsel_74kc_musl/omcproxy-2017-02-14-1fe6f48f/src/mrib.c:39:
/var/lib/buildbot/slaves/slave-lede-builds4/mipsel_74kc/build/sdk/build_dir/target-mipsel_74kc_musl/omcproxy-2017-02-14-1fe6f48f/src/mrib.c:57:34: error: braced-group within expression allowed only inside a function
 static uint32_t ipv4_rtr_alert = cpu_to_be32(0x94040000);
                                  ^
```
Linux kernel defines `__constant_cpu_to_be32` somewhere, but including its headers was messy.  It is used only once, so it is simpler to just spell out the constant.

Signed-off-by: Eneas U de Queiroz <cote2004-github@yahoo.com>